### PR TITLE
Update OptOutVocab.adoc

### DIFF
--- a/OptOutVocab.adoc
+++ b/OptOutVocab.adoc
@@ -14,61 +14,51 @@ endif::[]
 // table of contents goes here
 toc::[] 
 
-// [abstract]
-== Abstract
-
-This document provides a common vocabulary that seeks to standardize machine readable rights reservations and other rightholder opt-outs from using works protected by copyright and related rights in the context of AI/ML training and other forms of Text and Data Mining (TDM). It has been developed to address one of the issues identified in this April 2024 policy brief by https://openfuture.eu[Open Future]: https://openfuture.eu/wp-content/uploads/2024/05/240516considerations_of_opt-out_compliance_policies.pdf[Considerations for opt-out compliance policies by AI model developers]. The paper identifies four different concepts that require consensus among stakeholders in order to ensure that opt-outs / rights reservation can be expressed in a way that is effective, scalable, and able to meet the needs of both rights holders and AI model developers. the four concepts are (in bold): 
-
-> If you tell us what **{identifier}** you want to opt out from which uses **{vocabulary}** via these means **{infrastructure}** then we will do this **{effect of opt-out}**.
-
-This document focuses on the **{vocabulary}** piece of this statement by describing a proposed opt-out Vocabulary that can be used to describe whether one or more assets may be used as part of a data mining or AI/ML training workflow. The purpose of the vocabulary is to provide a stable set of categories that can be used by rightholders to specify the scope of opt-outs / rights reservations they wish to make. A stable, well defined set of rights reservations will ensure that opt-out reservation can be exchanged across value change and that different systems to communicate, process and store opt-out & rights reservations can be designed in an interoperable way. The vocabulary is implementation agnostic and can be implemented in a variety of opt-out schemes including `location-based` and `unit-based` schemes. 
-
-// page break
-<<<
-
 // start numbering the sections from here...
 :sectnums:
 
-== Terms and Definitions
+== Purpose
 
-Asset:: A digital file or stream of data containing content and usually with associated metadata. 
+The purpose of this document is to provide a common vocabulary that can be used for machine-readable rights reservations / opt-outs by rightholders who wish to restrict the use of their works and other subject matter for the purpose of AI/ML training and other forms of Text and Data Mining (TDM). 
 
-Rightholder:: Person or organization that owns the legal rights to something. In this context preliminary holders of copyright and related rights.
+The elements of the vocabulary can be used to describe in a standardized way the types of uses that a rightholder may wish to restrict (or allow), thereby ensuring that rights reservations / opt-outs can be communicated, processed and stored in a consistent and interoperable manner. The vocabulary is agnostic to the technical implementations of opt-out systems and is designed to ensure that opt-out information can be effectively exchanged between different systems.
 
-Location-based identifiers:: A machine-readable location, such as a domain or URL, for use in identification of assets. 
+== Definitions
 
-Unit-based identifiers:: A machine-readable piece of information that identifies a single asset (unit), regardless of where the asset is located, either through the embedding of that information directly into the asset or via a separate database or registry.
+Asset:: A digital file or stream of data containing protected works or other subject matter, usually with associated metadata. 
 
-AI/ML Training:: The pre-training, training and fine-tuning of AI Models. 
+Rightholder:: A person or organization that owns the legal rights to something. In this context, holders of copyright and related rights.
 
-== Structure
+AI/ML Training:: The pre-training, training, and fine-tuning of AI models.
 
-The vocabulary consists of the overarching Text and Data Mining (`TDM`) category and a number or more specific use cases that can be independently addressed. The overarching `TDM` category is derived from the definition of Text and Data mining in https://eur-lex.europa.eu/eli/dir/2019/790/oj#art_2.tit_1[Article 2(2) of the European Union's Copyright in the Digital Single Market Directive]. TDM includes not only the specific use cases currently included in this vocabulary, but also other forms of TDM for which additional categories could be defined in future, as technology evolves.
+== Vocabulary Structure
 
-For the purposes of this vocabulary, TDM is not understood to cover indexing of content for the purpose of online search. This use case is addressed using a `location-based` schema such as the existing https://datatracker.ietf.org/doc/html/rfc9309[Robots Exclusion Protocol]. 
-
-Currently the proposed vocabulary contains two use cases that relate to the use of assets for AI/ML training purposes.
+The vocabulary consists of the overarching TDM (Text and Data Mining) category and a number of specific use cases that can be addressed independently. The overarching category `TDM` corresponds to the definition of Text and Data Mining in https://eur-lex.europa.eu/eli/dir/2019/790/oj#d1e845-92-1[Article 2(2) of the European Union Directive on Copyright in the Digital Single Market].
 
 == Proposed Vocabulary
 
-=== Categories
+The following categories are defined for use in the opt-out vocabulary:
 
-The following categories are proposed for use in the Opt-Out Vocabulary.
+`TDM`: Text and Data Mining. The act of using one or more assets in the context of any automated analytical technique aimed at analyzing text and data in digital form in order to generate information which includes but is not limited to patterns, trends and correlations for purposes other than scientific research.
 
-TDM:: Text and Data Mining. The act of using one or more assets in the context of any automated analytical technique aimed at analysing text and data in digital form in order to generate information which includes but is not limited to patterns, trends and correlations for purposes other than scientific research.
+For the purposes of this vocabulary, TDM is not intended to cover the indexing of content for the purpose of online search. This use case is addressed by the existing https://datatracker.ietf.org/doc/html/rfc9309[Robots Exclusion Protocol]. 
 
-AI Training:: The act of training AI/ML models that are NOT capable of generating text, images, and other synthetic content on one or more assets as input. Examples are models than can be used for classification or object detection.
+`Generative AI Training`: The act of training AI/ML models that are capable of generating text, images, and other synthetic content using one or more assets as input.
 
-Generative AI Training:: The act of training AI/ML models that are capable of generating text, images, and other synthetic content on one or more assets as input.
+`AI Training`: The act of training AI/ML models that are NOT capable of generating text, images, and other synthetic content using one or more assets as input. Examples include models that can be used for classification or object detection.
 
-This list of categories may be expanded with categories addressing additional uses cases should such use cases emerge. In addition to these categories defined in the vocabulary, it is also expected that some systems implementing this vocabulary may extend this list with additional categories for their particular needs. 
+This list of categories may be expanded in the future, should a consensus emerge between stakeholders, to include categories that address additional use cases as they emerge. In addition to these categories defined in the vocabulary, it is also expected that some systems implementing this vocabulary may extend this list with additional categories for their particular needs. Systems referencing the vocabulary must not introduce additional categories that encompass existing categories defined in the vocabulary.
 
 === Relationship
 
-The `TDM` category is the overarching category that includes the various types of AI training, as they are considered to be forms of TDM.  As such, if a rights-holder opts out of or reserves the rights to `TDM`, they are opting out of  other categories that may be defined in the future as well. Of course, those other categories could be independently addressed so as to affect only the specific use case covered by that category. 
+The `TDM` category is the overarching category that includes the two categories related to AI/ML training, as they are considered to be forms of `TDM`. As such, when a rights holder reserves the rights to `TDM`, they also opt out of these categories. AI model developers processing opt-outs must therefore interpret an opt-out from `TDM` to also mean an opt-out from `Generative AI Training` and `AI Training`. All categories other than `TDM` can be addressed independently to affect only the specific use case covered by that category. 
 
-<<categories-diagram, The figure below>> shows the relationship between the currently defined categories.
+<<categories-diagram, The figure below>> shows the relationship between the currently defined categories:
 
 [[categories.diagram]]
 .Relationship between the categories
 image::categories.drawio.svg[Example diagram showing the relationship between the categories]
+
+== Usage
+
+The vocabulary may be used by declaring that an opt-out system or entity expressing or processing opt-outs uses the terms defined in section 4 of the vocabulary in accordance with how they are defined in this vocabulary.


### PR DESCRIPTION
New, pared down version of the original document. In response to discussions on the oo-vocab mailing this version removes the mentions of location/unit based identifiers and some other external references